### PR TITLE
`egor` is an suggested install now, but required for the `ego_netwrit…

### DIFF
--- a/vignettes/ego_netwrite.Rmd
+++ b/vignettes/ego_netwrite.Rmd
@@ -543,7 +543,7 @@ install.packages("egor")
 
 Once installed, users can specify `egor = TRUE` in `ego_netwrite` to create an `egor` object based on the ego list, alter list and alter-alter edgelist fed into the function. This object is given the simple name `egor`:
 
-```{r egor}
+```{r egor, eval = FALSE}
 egor
 ```
 


### PR DESCRIPTION
…e` vignette. Updated the vignette to resolve this issue.